### PR TITLE
Adding in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+---
+
+version: '3'
+services:
+  cif:
+    build: cif-docker/
+    container_name: cif
+    restart: on-failure
+    ports:
+      - 5000:5000
+    volumes:
+      - cif-config:/etc/cif
+      - cif-logs:/var/log/cif
+      - cif-db:/var/lib/cif
+volumes:
+  cif-config:
+  cif-logs:
+  cif-db:


### PR DESCRIPTION
We use a lot of docker-compose over here, so thought maybe this would be useful for other folks!  Allows for running `docker-compose up` in the root of the repository to get a freshly built image and running container.